### PR TITLE
feat: hide server-info

### DIFF
--- a/.config/example.yml
+++ b/.config/example.yml
@@ -163,3 +163,6 @@ id: 'aid'
 #allowedPrivateNetworks: [
 #  '127.0.0.1/32'
 #]
+
+# サーバー情報を隠す (default: false)
+#hideServerInfo: true

--- a/src/daemons/server-stats.ts
+++ b/src/daemons/server-stats.ts
@@ -1,6 +1,7 @@
 import * as si from 'systeminformation';
 import Xev from 'xev';
 import * as osUtils from 'os-utils';
+import config from '../config';
 
 const ev = new Xev();
 
@@ -26,18 +27,18 @@ export default function() {
 		const fsStats = await fs();
 
 		const stats = {
-			cpu: roundCpu(cpu),
+			cpu: config.hideServerInfo ? -1 : roundCpu(cpu),
 			mem: {
-				used: round(memStats.used),
-				active: round(memStats.active),
+				used: config.hideServerInfo ? -1 : round(memStats.used),
+				active: config.hideServerInfo ? -1 : round(memStats.active),
 			},
 			net: {
-				rx: round(Math.max(0, netStats.rx_sec)),
-				tx: round(Math.max(0, netStats.tx_sec)),
+				rx: config.hideServerInfo ? -1 : round(Math.max(0, netStats.rx_sec)),
+				tx: config.hideServerInfo ? -1 : round(Math.max(0, netStats.tx_sec)),
 			},
 			fs: {
-				r: round(Math.max(0, fsStats.rIO_sec)),
-				w: round(Math.max(0, fsStats.wIO_sec)),
+				r: config.hideServerInfo ? -1 : round(Math.max(0, fsStats.rIO_sec)),
+				w: config.hideServerInfo ? -1 : round(Math.max(0, fsStats.wIO_sec)),
 			}
 		};
 		ev.emit('serverStats', stats);

--- a/src/server/api/endpoints/server-info.ts
+++ b/src/server/api/endpoints/server-info.ts
@@ -1,6 +1,7 @@
 import * as os from 'os';
 import * as si from 'systeminformation';
 import define from '../define';
+import config from '../../../config';
 
 export const meta = {
 	requireCredential: false as const,
@@ -19,17 +20,17 @@ export default define(meta, async () => {
 	const fsStats = await si.fsSize();
 
 	return {
-		machine: os.hostname(),
+		machine: config.hideServerInfo ? 'Unknown' : os.hostname(),
 		cpu: {
-			model: os.cpus()[0].model,
-			cores: os.cpus().length
+			model: config.hideServerInfo ? 'Unknown' : os.cpus()[0].model,
+			cores: config.hideServerInfo ? 'Unknown' : os.cpus().length
 		},
 		mem: {
-			total: memStats.total
+			total: config.hideServerInfo ? 'Unknown' : memStats.total
 		},
 		fs: {
-			total: fsStats[0].size,
-			used: fsStats[0].used,
+			total: config.hideServerInfo ? 'Unknown' : fsStats[0].size,
+			used: config.hideServerInfo ? 'Unknown' : fsStats[0].used,
 		},
 	};
 });

--- a/src/server/web/index.ts
+++ b/src/server/web/index.ts
@@ -226,7 +226,7 @@ router.get(['/@:user', '/@:user/:sub'], async (ctx, next) => {
 			icon: meta.iconUrl
 		});
 		setCache(ctx, 'public, max-age=30');
-	} else if (!host) { 
+	} else if (!host) {
 		const isExisted = await UsedUsernames.count({ username: username.toLowerCase() });
 		ctx.status = isExisted > 0 ? 410 : 404;
 		return;
@@ -376,14 +376,14 @@ router.get('/info', async ctx => {
 
 	await ctx.render('info', {
 		version: config.version,
-		machine: os.hostname(),
-		os: os.platform(),
-		node: process.version,
-		psql: await getConnection().query('SHOW server_version').then(x => x[0].server_version),
-		redis: redis.server_info.redis_version,
+		machine: config.hideServerInfo ? 'Unknown' : os.hostname(),
+		os: config.hideServerInfo ? 'Unknown' : os.platform(),
+		node: config.hideServerInfo ? 'Unknown' : process.version,
+		psql: config.hideServerInfo ? 'Unknown' : await getConnection().query('SHOW server_version').then(x => x[0].server_version),
+		redis: config.hideServerInfo ? 'Unknown' : redis.server_info.redis_version,
 		cpu: {
-			model: os.cpus()[0].model,
-			cores: os.cpus().length
+			model: config.hideServerInfo ? 'Unknown' : os.cpus()[0].model,
+			cores: config.hideServerInfo ? 'Unknown' : os.cpus().length
 		},
 		emojis: emojis,
 		meta: meta,


### PR DESCRIPTION
# Summary
サーバー情報を隠せるようにする
認証不要のAPIでもサーバー情報を取得できることから
一部のインスタンスの管理者からセキュリティ上の懸念があるため