### PR TITLE
fix: ドライブ容量上限超過はHTTP 400番台を返すように

### DIFF
--- a/src/server/api/endpoints/drive/files/create.ts
+++ b/src/server/api/endpoints/drive/files/create.ts
@@ -6,6 +6,7 @@ import define from '../../../define';
 import { apiLogger } from '../../../logger';
 import { ApiError } from '../../../error';
 import { DriveFiles } from '../../../../../models';
+import { IdentifiableError } from '../../../../../misc/identifiable-error';
 
 export const meta = {
 	desc: {
@@ -74,7 +75,13 @@ export const meta = {
 			message: 'Invalid file name.',
 			code: 'INVALID_FILE_NAME',
 			id: 'f449b209-0c60-4e51-84d5-29486263bfd4'
-		}
+		},
+
+		noFreeSpace: {
+			message: 'Cannot upload the file because you have no free space of drive.',
+			code: 'NO_FREE_SPACE',
+			id: 'd08dbc37-a6a9-463a-8c47-96c32ab5f064',
+		},
 	}
 };
 
@@ -99,7 +106,12 @@ export default define(meta, async (ps, user, _, file, cleanup) => {
 		const driveFile = await create(user, file.path, name, null, ps.folderId, ps.force, false, null, null, ps.isSensitive);
 		return await DriveFiles.pack(driveFile, { self: true });
 	} catch (e) {
-		apiLogger.error(e);
+		if (e instanceof Error || typeof e === 'string') {
+			apiLogger.error(e);
+		}
+		if (e instanceof IdentifiableError) {
+			if (e.id === 'c6244ed2-a39a-4e1c-bf93-f0fbd7764fa6') throw new ApiError(meta.errors.noFreeSpace);
+		}
 		throw new ApiError();
 	} finally {
 		cleanup!();

--- a/src/services/drive/add-file.ts
+++ b/src/services/drive/add-file.ts
@@ -21,6 +21,7 @@ import { isDuplicateKeyValueError } from '../../misc/is-duplicate-key-value-erro
 import * as S3 from 'aws-sdk/clients/s3';
 import { getS3 } from './s3';
 import * as sharp from 'sharp';
+import { IdentifiableError } from '../../misc/identifiable-error';
 
 const logger = driveLogger.createSubLogger('register', 'yellow');
 
@@ -357,7 +358,7 @@ export default async function(
 		// If usage limit exceeded
 		if (usage + info.size > driveCapacity) {
 			if (Users.isLocalUser(user)) {
-				throw new Error('no-free-space');
+				throw new IdentifiableError('c6244ed2-a39a-4e1c-bf93-f0fbd7764fa6', 'No free space.');
 			} else {
 				// (アバターまたはバナーを含まず)最も古いファイルを削除する
 				deleteOldFile(user as IRemoteUser);


### PR DESCRIPTION
## Summary
ドライブ上限超過はInternal ErrorではなくBad Request
もしかしたらローカルユーザーのドライブの上限すら要らないかもしれないのだけど
エラーで返すのもユーザーに親切ではないと感じる