### PR TITLE
Add: Option of Showing Confirmation

### DIFF
--- a/locales/en-US.yml
+++ b/locales/en-US.yml
@@ -857,6 +857,13 @@ defaultRenoteVisibility: "Default visibility (Renote)"
 defaultRenoteLocalOnly: "Local Only (Renote)"
 defaultRenoteRemoteFollowersOnly: "Remote Followers and Local (Renote)"
 welcomeBack: "Welcome back, {x}."
+showNoteDeleteConfirm: "Show confirmation dialog before deleting a post"
+showFollowConfirm: "Show confirmation dialog before following someone"
+showUnfollowConfirm: "Show confirmation dialog before unfollowing someone"
+showRenoteConfirm: "Show confirmation dialog before renoting"
+showUnrenoteConfirm: "Show confirmation dialog before unrenoting"
+showVoteConfirm: "Show confirmation dialog before voting"
+voteConfirm: "Are you sure that you want to vote?"
 
 _template:
   edit: "Edit Template..."

--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -894,6 +894,13 @@ defaultRenoteVisibility: "デフォルトの公開範囲 (リノート)"
 defaultRenoteLocalOnly: "ローカルのみ (リノート)"
 defaultRenoteRemoteFollowersOnly: "リモートフォロワーとローカル (リノート)"
 welcomeBack: "おかえりなさい、{x}さん。"
+showNoteDeleteConfirm: "投稿を削除する前に確認ダイアログを表示する"
+showFollowConfirm: "フォローする前に確認ダイアログを表示する"
+showUnfollowConfirm: "フォローを解除する前に確認ダイアログを表示する"
+showRenoteConfirm: "リノートする前に確認ダイアログを表示する"
+showUnrenoteConfirm: "リノート解除する前に確認ダイアログを表示する"
+showVoteConfirm: "投票する前に確認ダイアログを表示する"
+voteConfirm: "投票しますか？"
 
 _template:
   edit: "定型文を編集…"

--- a/src/client/components/note.vue
+++ b/src/client/components/note.vue
@@ -568,7 +568,7 @@ export default defineComponent({
 				case 'quote': quote(); break;
 				case 'renoteQuote': renote(); quote(); break;
 			}
-			
+
 		},
 
 		renoteDirectly() {
@@ -677,7 +677,7 @@ export default defineComponent({
 		},
 
 		async delEdit() {
-			const canceled = this.$store.state.showDeleteAndEditConfirm && (await os.dialog({
+			const canceled = this.$store.state.showNoteDeleteConfirm && (await os.dialog({
 				type: 'warning',
 				text: this.$ts.deleteAndEditConfirm,
 				showCancelButton: true
@@ -767,7 +767,7 @@ export default defineComponent({
 					}]
 					: []
 				),
-				// 自分でない、パブリック, ホーム なノート 
+				// 自分でない、パブリック, ホーム なノート
 				...(!this.isMyNote && ['public', 'home'].includes(this.appearNote.visibility) ? [
 					null,
 					{

--- a/src/client/components/poll.vue
+++ b/src/client/components/poll.vue
@@ -84,14 +84,20 @@ export default defineComponent({
 		toggleShowResult() {
 			this.showResult = !this.showResult;
 		},
-		vote(id) {
+		async vote(id) {
 			if (this.closed || !this.poll.multiple && this.poll.choices.some(c => c.isVoted)) return;
-			os.api('notes/polls/vote', {
+			const canceled = this.$store.state.showVoteConfirm && (await os.dialog({
+				type: 'question',
+				text: this.$ts.voteConfirm,
+				showCancelButton: true,
+			})).canceled;
+			if (canceled) return;
+
+			await os.api('notes/polls/vote', {
 				noteId: this.note.id,
 				choice: id
-			}).then(() => {
-				if (!this.showResult) this.showResult = !this.poll.multiple;
 			});
+			if (!this.showResult) this.showResult = !this.poll.multiple;
 		}
 	}
 });

--- a/src/client/pages/settings/general.vue
+++ b/src/client/pages/settings/general.vue
@@ -21,6 +21,12 @@
 			{{ $ts.confirmBeforePost }}
 			<template #desc>{{$ts.confirmBeforePostDesc}}</template>
 		</FormSwitch>
+		<FormSwitch v-model:value="showNoteDeleteConfirm">{{ $ts.showNoteDeleteConfirm }}</FormSwitch>
+		<FormSwitch v-model:value="showFollowConfirm">{{ $ts.showFollowConfirm }}</FormSwitch>
+		<FormSwitch v-model:value="showUnfollowConfirm">{{ $ts.showUnfollowConfirm }}</FormSwitch>
+		<FormSwitch v-model:value="showRenoteConfirm">{{ $ts.showRenoteConfirm }}</FormSwitch>
+		<FormSwitch v-model:value="showUnrenoteConfirm">{{ $ts.showUnrenoteConfirm }}</FormSwitch>
+		<FormSwitch v-model:value="showVoteConfirm">{{ $ts.showVoteConfirm }}</FormSwitch>
 	</FormGroup>
 
 	<FormSelect v-model:value="serverDisconnectedBehavior">
@@ -214,6 +220,12 @@ export default defineComponent({
 		iconShape: defaultStore.makeGetterSetter('iconShape'),
 		noteCollapseThreshold: defaultStore.makeGetterSetter('noteCollapseThreshold'),
 		confirmBeforePost: defaultStore.makeGetterSetter('confirmBeforePost'),
+		showNoteDeleteConfirm: defaultStore.makeGetterSetter('showNoteDeleteConfirm'),
+		showFollowConfirm: defaultStore.makeGetterSetter('showFollowConfirm'),
+		showUnfollowConfirm: defaultStore.makeGetterSetter('showUnfollowConfirm'),
+		showRenoteConfirm: defaultStore.makeGetterSetter('showRenoteConfirm'),
+		showUnrenoteConfirm: defaultStore.makeGetterSetter('showUnrenoteConfirm'),
+		showVoteConfirm: defaultStore.makeGetterSetter('showVoteConfirm'),
 		aiChanMode: defaultStore.makeGetterSetter('aiChanMode'),
 		renoteButtonMode: defaultStore.makeGetterSetter('renoteButtonMode'),
 	},

--- a/src/client/store.ts
+++ b/src/client/store.ts
@@ -323,6 +323,36 @@ export const defaultStore = markRaw(new Storage('base', {
 		default: false
 	},
 
+	showNoteDeleteConfirm: {
+		where: 'account',
+		default: true
+	},
+
+	showFollowConfirm: {
+		where: 'account',
+		default: false
+	},
+
+	showUnfollowConfirm: {
+		where: 'account',
+		default: true
+	},
+
+	showRenoteConfirm: {
+		where: 'account',
+		default: false
+	},
+
+	showUnrenoteConfirm: {
+		where: 'account',
+		default: false
+	},
+
+	showVoteConfirm: {
+		where: 'account',
+		default: true
+	},
+
 	tryNewPostForm: {
 		where: 'device',
 		default: false


### PR DESCRIPTION
## Summary

誤操作防止のためにダイアログを設け、以下のようにユーザーの裁量で設定可能にしたい
Mastodonの設定と同じような実装である

<img width="963" alt="Screen Shot 2022-11-10 at 00 40 29" src="https://user-images.githubusercontent.com/83960488/200875348-873c28e8-b428-43d4-997a-4cd51e051058.png">
