### PR TITLE
招待コードを失効する機能　Feat: Revoke Invitation Codes

### DIFF
--- a/locales/en-US.yml
+++ b/locales/en-US.yml
@@ -873,6 +873,8 @@ showVoteConfirm: "Show confirmation dialog before voting"
 voteConfirm: "Are you sure that you want to vote?"
 deleteAccount: "Delete Account"
 deleteAccountConfirm: "Are you sure that you want to delete this account?"
+inviteRevoke: "Revoke All Invitation Codes"
+inviteRevokeConfirm: "Are you sure that you want to revoke all invitation codes?"
 
 _template:
   edit: "Edit Template..."

--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -910,6 +910,8 @@ showVoteConfirm: "投票する前に確認ダイアログを表示する"
 voteConfirm: "投票しますか？"
 deleteAccount: "アカウント削除"
 deleteAccountConfirm: "本当にこのアカウントを削除しますか？"
+inviteRevoke: "全ての招待コードを失効する"
+inviteRevokeConfirm: "本当に全ての招待コードを失効させますか？"
 
 _template:
   edit: "定型文を編集…"

--- a/src/client/pages/instance/settings.vue
+++ b/src/client/pages/instance/settings.vue
@@ -61,7 +61,8 @@
 					<MkInput v-model:value="disableInvitationReason">{{ $ts.disableInvitationReason }}</MkInput>
 					<MkButton primary @click="save(true)"><fa :icon="faSave"/> {{ $ts.save }}</MkButton>
 				</template>
-				<MkButton v-else @click="invite">{{ $ts.invite }}</MkButton>
+				<MkButton v-if="!enableRegistration && enableInvitation" @click="invite">{{ $ts.invite }}</MkButton>
+				<MkButton v-if="!enableRegistration && enableInvitation" @click="inviteRevoke" danger>{{ $ts.inviteRevoke }}</MkButton>
 			</template>
 		</div>
 	</section>
@@ -497,6 +498,21 @@ export default defineComponent({
 					text: x.code
 				});
 			}).catch(e => {
+				os.dialog({
+					type: 'error',
+					text: e
+				});
+			});
+		},
+
+		inviteRevoke() {
+			os.api('admin/invite-revoke').then(x => {
+				os.dialog({
+				type: 'warning',
+				showCancelButton: true,
+				text: this.$ts.inviteRevokeConfirm,
+				});
+			}).then(({ canceled }) => {
 				os.dialog({
 					type: 'error',
 					text: e

--- a/src/server/api/endpoints/admin/invite-revoke.ts
+++ b/src/server/api/endpoints/admin/invite-revoke.ts
@@ -1,0 +1,20 @@
+import define from '../../define';
+import { RegistrationTickets } from '../../../../models';
+
+export const meta = {
+	desc: {
+		'ja-JP': '招待コードを失効します。'
+	},
+
+	tags: ['admin'],
+
+	requireCredential: true as const,
+	requireModerator: true,
+
+	params: {}
+};
+
+export default define(meta, async () => {
+	await RegistrationTickets.delete({
+	});
+});


### PR DESCRIPTION
## Summary
一度招待コードを発行してしまうと、データベースを操作しない限り、コードを消すことができないため