### PR TITLE
お知らせの表示を改善

### DIFF
--- a/locales/en-US.yml
+++ b/locales/en-US.yml
@@ -873,6 +873,7 @@ showVoteConfirm: "Show confirmation dialog before voting"
 voteConfirm: "Are you sure that you want to vote?"
 deleteAccount: "Delete Account"
 deleteAccountConfirm: "Are you sure that you want to delete this account?"
+createdAt: "Created at"
 
 _template:
   edit: "Edit Template..."

--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -910,6 +910,7 @@ showVoteConfirm: "投票する前に確認ダイアログを表示する"
 voteConfirm: "投票しますか？"
 deleteAccount: "アカウント削除"
 deleteAccountConfirm: "本当にこのアカウントを削除しますか？"
+createdAt: "作成日時"
 
 _template:
   edit: "定型文を編集…"

--- a/src/client/components/announcements-window.vue
+++ b/src/client/components/announcements-window.vue
@@ -13,7 +13,9 @@
 			<mfm :text="currentAnnouncement.text" :once="false"/>
 			<img v-if="currentAnnouncement.imageUrl" :src="currentAnnouncement.imageUrl"/>
 		</div>
-		<div class="time"><MkTime :time="currentAnnouncement.createdAt" mode="detail"/></div>
+		<div class="footer">
+			<div>{{ $ts.createdAt }}: <MkTime :time="currentAnnouncement.createdAt" mode="detail"/></div>
+		</div>
 	</div>
 	<template #footer>
 		<div class="navigation">
@@ -115,6 +117,11 @@ export default defineComponent({
 			font-weight: bold;
 			margin-bottom: 1em;
 			font-size: 1em;
+		}
+		> .footer {
+			margin: var(--margin) 0 var(--margin) 0;
+			font-size: 85%;
+			opacity: 0.75;
 		}
 }
 .navigation {

--- a/src/client/pages/announcements.vue
+++ b/src/client/pages/announcements.vue
@@ -7,6 +7,9 @@
 				<Mfm :text="announcement.text" :once="false"/>
 				<img v-if="announcement.imageUrl" :src="announcement.imageUrl"/>
 			</div>
+			<div class="footer">
+				<div>{{ $ts.createdAt }}: <MkTime :time="announcement.createdAt" mode="detail"/></div>
+			</div>
 			<div class="_footer" v-if="$i && !announcement.isRead">
 				<MkButton @click="read(items, announcement, i)" primary><Fa :icon="faCheck"/> {{ $ts.gotIt }}</MkButton>
 			</div>
@@ -64,6 +67,11 @@ export default defineComponent({
 				max-height: 300px;
 				max-width: 100%;
 			}
+		}
+		> .footer {
+			margin: var(--margin) 0 var(--margin) 0;
+			font-size: 85%;
+			opacity: 0.75;
 		}
 	}
 }

--- a/src/client/ui/visitor/b.vue
+++ b/src/client/ui/visitor/b.vue
@@ -35,7 +35,9 @@
 	<transition name="tray">
 		<div v-if="showMenu" class="menu">
 			<MkA to="/" class="link" active-class="active"><Fa :icon="faHome" class="icon"/>{{ $ts.home }}</MkA>
+			<MkA to="/announcements" class="link" active-class="active"><Fa :icon="faBroadcastTower" class="icon"/>{{ $ts.announcements }}</MkA>
 			<MkA to="/explore" class="link" active-class="active"><Fa :icon="faHashtag" class="icon"/>{{ $ts.explore }}</MkA>
+			<MkA to="/featured" class="link" active-class="active"><Fa :icon="faFireAlt" class="icon"/>{{ $ts.featured }}</MkA>
 			<MkA to="/channels" class="link" active-class="active"><Fa :icon="faSatelliteDish" class="icon"/>{{ $ts.channel }}</MkA>
 			<div class="action">
 				<button class="_buttonPrimary" @click="signup()">{{ $ts.signup }}</button>

--- a/src/client/ui/visitor/header.vue
+++ b/src/client/ui/visitor/header.vue
@@ -3,6 +3,7 @@
 	<div class="wide" v-if="narrow === false">
 		<div class="content">
 			<MkA to="/" class="link" active-class="active"><Fa :icon="faHome" class="icon"/>{{ $ts.home }}</MkA>
+			<MkA to="/announcements" class="link" active-class="active"><Fa :icon="faBroadcastTower" class="icon"/>{{ $ts.announcements }}</MkA>
 			<MkA to="/explore" class="link" active-class="active"><Fa :icon="faHashtag" class="icon"/>{{ $ts.explore }}</MkA>
 			<MkA to="/featured" class="link" active-class="active"><Fa :icon="faFireAlt" class="icon"/>{{ $ts.featured }}</MkA>
 			<MkA to="/channels" class="link" active-class="active"><Fa :icon="faSatelliteDish" class="icon"/>{{ $ts.channel }}</MkA>
@@ -41,7 +42,7 @@
 
 <script lang="ts">
 import { defineComponent } from 'vue';
-import { faSearch, faHome, faFireAlt, faHashtag, faSatelliteDish, faBars } from '@fortawesome/free-solid-svg-icons';
+import { faSearch, faHome, faFireAlt, faHashtag, faSatelliteDish, faBars, faBroadcastTower } from '@fortawesome/free-solid-svg-icons';
 import XSigninDialog from '@/components/signin-dialog.vue';
 import XSignupDialog from '@/components/signup-dialog.vue';
 import * as os from '@/os';
@@ -58,7 +59,7 @@ export default defineComponent({
 		return {
 			narrow: null,
 			showMenu: false,
-			faSearch, faHome, faFireAlt, faHashtag, faSatelliteDish, faBars,
+			faSearch, faHome, faFireAlt, faHashtag, faSatelliteDish, faBars, faBroadcastTower,
 		};
 	},
 

--- a/src/client/ui/visitor/kanban.vue
+++ b/src/client/ui/visitor/kanban.vue
@@ -28,6 +28,9 @@
 								<Mfm :text="announcement.text"/>
 								<img v-if="announcement.imageUrl" :src="announcement.imageUrl"/>
 							</div>
+							<div class="footer">
+								<div>{{ $ts.createdAt }}: <MkTime :time="announcement.createdAt" mode="detail"/></div>
+							</div>
 						</section>
 					</MkPagination>
 				</div>
@@ -189,7 +192,7 @@ export default defineComponent({
 				box-sizing: border-box;
 				text-shadow: 0 0 8px black;
 				color: #fff;
-				
+
 				> .signup-disabled {
 					color: var(--infoWarnFg);
 					border: 2px dashed var(--infoWarnBg);
@@ -254,6 +257,11 @@ export default defineComponent({
 							}
 						}
 					}
+				}
+				> .footer {
+					margin: var(--margin) 0 var(--margin) 0;
+					font-size: 85%;
+					opacity: 0.75;
 				}
 			}
 


### PR DESCRIPTION
## Summary

- お知らせの登録日時の表記をまともに
- お知らせのリンクを追加する
![Screen Shot 2023-02-25 at 19 57 39](https://user-images.githubusercontent.com/83960488/221353186-f172b0e1-dfe6-4298-849c-1f225a4f1c47.png)
![Screen Shot 2023-02-25 at 19 58 06](https://user-images.githubusercontent.com/83960488/221353198-1b7d9959-cd30-472e-bc62-fcc713cf590b.png)
